### PR TITLE
a fix for "COBANG for Windows"

### DIFF
--- a/GOBANG/GOBANG for Windows/GOBANG.cpp
+++ b/GOBANG/GOBANG for Windows/GOBANG.cpp
@@ -395,6 +395,7 @@ int judge()
 	{
 		return 4;
 	}
+	return 0;
 }
 
 void tip()


### PR DESCRIPTION
a solution of warning on line 398:  Adding  "return 0;" in 398